### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amazon RDS (for MySQL) input plugin
+# Amazon RDS (for MySQL) input plugin for [Fluentd](http://fluentd.org)
 
 ## Overview
 - Amazon Web Services RDS(MySQL) general_log and slow_log input plugin.  


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
