### PR TITLE
if Connection error occurred to retry.

### DIFF
--- a/fluent-plugin-rds-log.gemspec
+++ b/fluent-plugin-rds-log.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-rds-log"
-  gem.version       = "0.1.3"
+  gem.version       = "0.1.4"
   gem.authors       = ["shinsaka"]
   gem.email         = ["shinx1265@gmail.com"]
   gem.description   = "Amazon RDS slow_log and general_log input plugin for Fluent event collector"

--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -1,0 +1,16 @@
+<source>
+  type rds_log
+  log_type general_log
+  host endpoint.abcdefghijkl.ap-northeast-1.rds.amazonaws.com
+  username testuser
+  password testuser
+  refresh_interval 30
+  auto_reconnect true
+  tag rds-general-log
+  add_host true
+</source>
+
+<match rds-general-log>
+  type file
+  path /tmp/rds-general-log
+</match>


### PR DESCRIPTION
こんにちは。(日本語の資料をslideshareで拝見しましたので日本語で！)
再度のpull requestです。

RDSを使っている場合DBを作りなおしたりすることが容易なので、結構やったりするケースが有ると思うのですが、その際にエラーを握りつぶしてしまっています。

一時的にmysqlなどに接続できないなどの際には一旦refresh_intervalだけ待って、再度接続を試みるという処理を加えました。

他のmysql系のプラグインを見てみると、
①毎回closeしてnewする。
②エラーが発生した場合のみ再接続

に分類されるようです。
自分もmysql系のプラグインをいくつか作ってますが基本①でやってますが、今回は②の方が今の実装だと修正しやすかったのでそちら側にしました。



