### PR TITLE
Fix handling nil data when a error occurs during connecting to RDS

### DIFF
--- a/lib/fluent/plugin/in_rds_log.rb
+++ b/lib/fluent/plugin/in_rds_log.rb
@@ -72,6 +72,7 @@ class Fluent::Rds_LogInput < Fluent::Input
     client = connect(host)
     return if client.nil?
     output_log_data = query(client)
+    return if output_log_data.nil?
     output_log_data.each do |row|
       row.delete_if{|key,value| value == ''}
       row['host'] = host if @add_host


### PR DESCRIPTION
Hi, I'm using fluent-plugin-rds-log for collect slow query logs in multiple RDS servers.
The other day I found the following error in the log of td-agent.

```
2016-12-05 12:02:31 +0000 [error]: fluent-plugin-rds-log: ERROR Occurred!
fluentd_1  | 2016-12-05 12:02:31 +0000 [error]: Query execution was interrupted
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/mysql2-0.3.21/lib/mysql2/client.rb:80:in `_query'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/mysql2-0.3.21/lib/mysql2/client.rb:80:in `block in query'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/mysql2-0.3.21/lib/mysql2/client.rb:79:in `handle_interrupt'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/mysql2-0.3.21/lib/mysql2/client.rb:79:in `query'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/fluent-plugin-rds-log-0.1.7/lib/fluent/plugin/in_rds_log.rb:85:in `query'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/fluent-plugin-rds-log-0.1.7/lib/fluent/plugin/in_rds_log.rb:74:in `output'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/fluent-plugin-rds-log-0.1.7/lib/fluent/plugin/in_rds_log.rb:65:in `block in watch'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/fluent-plugin-rds-log-0.1.7/lib/fluent/plugin/in_rds_log.rb:64:in `each'
fluentd_1  | /home/ubuntu/ruby/lib/ruby/gems/2.3.0/gems/fluent-plugin-rds-log-0.1.7/lib/fluent/plugin/in_rds_log.rb:64:in `watch'
```

Then I have noticed the plugin's code has a bug in case that executing query is failed. Please check this PR.
Let me know if it needs any information. Or you can reproduce this here. 
https://github.com/innossh/docker-fluentd-rds-log