### PR TITLE
Supress Abort error.log on RDS for MySQL 5.7

### DIFF
--- a/fluent-plugin-rds-log.gemspec
+++ b/fluent-plugin-rds-log.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_dependency "fluentd", [">= 0.10.30", "< 2"]
-  gem.add_dependency "mysql2",  "~> 0.3.11"
+  gem.add_dependency "mysql2",  "~> 0.3.17"
   gem.add_development_dependency 'rake', '~> 10.0', '>= 10.0.4'
   gem.add_development_dependency 'test-unit', '~> 3.1', '>= 3.1.0'
 end

--- a/fluent-plugin-rds-log.gemspec
+++ b/fluent-plugin-rds-log.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_dependency "fluentd", [">= 0.10.30", "< 2"]
-  gem.add_dependency "mysql2",  "~> 0.3.17"
+  gem.add_dependency "mysql2",  "~> 0.4.1"
   gem.add_development_dependency 'rake', '~> 10.0', '>= 10.0.4'
   gem.add_development_dependency 'test-unit', '~> 3.1', '>= 3.1.0'
 end


### PR DESCRIPTION
In MySQL 5.7 of RDS, `Aborted Connection` is output to error.log.
```
2017-07-04T09:58:45.968034Z 703463 [Note] Aborted connection 703463 to db: 'mysql' user: 'user_name' host: '10.x.x.x' (Got an error reading communication packets)
```

This happens when the mysql2 client closes.

https://github.com/brianmario/mysql2/pull/663

I want to version up mysql2 0.3.11 to at least 0.4.1
